### PR TITLE
Switch Generic Types to Unity's "Display Name"

### DIFF
--- a/_Demigiant.Libraries/DeInspektorEditor/DeInspektor.cs
+++ b/_Demigiant.Libraries/DeInspektorEditor/DeInspektor.cs
@@ -84,7 +84,7 @@ namespace DG.DeInspektorEditor
                 if (iterator.propertyType == SerializedPropertyType.Generic) {
                     // Struct/class as array element: add space to show expand button + use propertyType as label
                     GUILayout.Space(8);
-                    EditorGUILayout.PropertyField(iterator, new GUIContent(string.Format("{0} {1}", iterator.type, arrayElementIndex)), true, new GUILayoutOption[0]);
+                    EditorGUILayout.PropertyField(iterator, new GUIContent(string.Format("{0} {1}", iterator.displayName, arrayElementIndex)), true, new GUILayoutOption[0]);
                 } else EditorGUILayout.PropertyField(iterator, new GUIContent(""), true, new GUILayoutOption[0]);
             } else {
                 // Regular property


### PR DESCRIPTION
I *think* this the change I'm looking for (I had compiler problems getting the source version of DeInspektor running, so wasn't able to test).  But for context:

When Unity is showing the names of array items, it will show the contents of the first serializable string field it finds in the object.  I regularly abuse this with [HideInInspector] "name" fields that are set from code, like:

![screenshot 2017-01-23 12 14 02](https://cloud.githubusercontent.com/assets/271924/22218806/b1ccd306-e165-11e6-948f-cbc27e753adb.png)

![screenshot 2017-01-23 12 14 08](https://cloud.githubusercontent.com/assets/271924/22218813/b68abbba-e165-11e6-8043-6784a4bd0a6f.png)

Which shows up as:

![screenshot 2017-01-23 12 12 46](https://cloud.githubusercontent.com/assets/271924/22218825/be299f80-e165-11e6-937d-8c65bc6b1f6a.png)

However, with DeInspektor, it's showing the type, so just:

![screenshot 2017-01-23 12 13 09](https://cloud.githubusercontent.com/assets/271924/22218837/c4898566-e165-11e6-804c-89b2a7e5add6.png)


Pretty sure this is the only change I need to get the Unity behavior, which would be great!